### PR TITLE
don't include unistd.h on windows

### DIFF
--- a/src/TUIO/TuioServer.cpp
+++ b/src/TUIO/TuioServer.cpp
@@ -20,7 +20,10 @@
 */
 
 #include "TuioServer.h"
+
+#ifndef WIN32
 #include "unistd.h"
+#endif
 
 using namespace TUIO;
 using namespace osc;


### PR DESCRIPTION
Hi, not sure how active this repo is, but it still seemed the most relevant addon for Tuio support in OF, so here is a fix I needed to do to get it building on windows.